### PR TITLE
Dropped anchor in favor of explicit 'before'

### DIFF
--- a/manifests/log_drop_chain.pp
+++ b/manifests/log_drop_chain.pp
@@ -33,7 +33,8 @@ define base_firewall::log_drop_chain () {
     log_level  => 7,
     chain      => $drop_chain,
     provider   => $provider,
-  }->
+    before     => Firewall["001 drop ${chain} ${protocol}"],
+  }
 
   firewall { "001 drop ${chain} ${protocol}":
     proto    => 'all',


### PR DESCRIPTION
This anchor caused a dependency loop when testing on puppet 6.
Root cause of this depedency loop was not determined.